### PR TITLE
Debug ios packager connection crash

### DIFF
--- a/ios/Rehand/AppDelegate.swift
+++ b/ios/Rehand/AppDelegate.swift
@@ -62,11 +62,8 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 
   override func bundleURL() -> URL? {
 #if DEBUG
-    // Force Metro host:port (avoid localhost on device; override any saved value)
-    let provider = RCTBundleURLProvider.sharedSettings()
-    provider.resetToDefaults()
-    provider.jsLocation = "192.168.68.200:8081"
-    return provider.jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+    // Use default settings for Metro bundler
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else
     return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 #endif

--- a/ios/Rehand/Info.plist
+++ b/ios/Rehand/Info.plist
@@ -61,6 +61,8 @@
     <string>Allow $(PRODUCT_NAME) to access your photos</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>Potrzebujemy dostępu do Twojej lokalizacji tylko podczas korzystania z funkcji, które tego wymagają, aby poprawić działanie aplikacji. Nie śledzimy ani nie zapisujemy Twojego położenia.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Potrzebujemy dostępu do sieci lokalnej, aby połączyć się z serwerem deweloperskim podczas debugowania aplikacji.</string>
     <key>NSUserActivityTypes</key>
     <array>
       <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>


### PR DESCRIPTION
Remove hardcoded Metro bundler IP and add local network usage description to fix app crashes in debug mode on iOS devices.

The application was crashing with "Couldn't connect to packager" errors in debug mode on iOS devices because `AppDelegate.swift` contained a hardcoded IP address for the Metro bundler, which was often inaccessible. This PR removes the hardcoded IP and adds `NSLocalNetworkUsageDescription` to ensure proper network access for debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-33223005-272b-443f-8cd5-9ce52d85b3b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33223005-272b-443f-8cd5-9ce52d85b3b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

